### PR TITLE
chore: add Makefile with serve, validate, and check targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ stratolab.github.io/
 ├── initial-research.md            # Research planning guide
 ├── .github/
 │   └── PULL_REQUEST_TEMPLATE.md  # PR checklist (testing, safety, quality)
+├── Makefile                       # Developer shortcuts (serve, validate, check)
+├── serve.sh                       # Local HTTP server script
 ├── CONTRIBUTING.md                # Human contributor guide
 └── AGENTS.md                      # (This file) AI agent guidelines
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,17 +30,27 @@ If not installed, download from [python.org/downloads](https://www.python.org/do
 
 ### Starting the Local Server
 
-**Using the helper script (recommended for macOS/Linux):**
+**Using Make (recommended for macOS/Linux):**
+
+```bash
+make serve
+```
+
+Then open your browser to [http://localhost:8000](http://localhost:8000)
+
+**Make options:**
+- `make open` — Start server and open browser automatically
+- `make serve PORT=3000` — Use a different port
+
+**Using the helper script directly (alternative):**
+
+The `make` targets delegate to `./serve.sh`. You can also run it directly:
 
 ```bash
 ./serve.sh
 ```
 
-Then open your browser to [http://localhost:8000](http://localhost:8000)
-
-**Script options:**
-- `./serve.sh -o` — Start server and open browser automatically
-- `./serve.sh -p 3000` — Use a different port
+Script options: `./serve.sh -o` (open browser), `./serve.sh -p 3000` (custom port)
 
 **Manual method (Windows or if script doesn't work):**
 
@@ -69,7 +79,7 @@ Press `Ctrl+C` in the terminal where the server is running.
 **"Address already in use" error:**
 
 Another program is using port 8000. Either stop that program, or use a
-different port: `./serve.sh -p 3001`
+different port: `make serve PORT=3001` or `./serve.sh -p 3001`
 
 **Changes not appearing:**
 
@@ -84,6 +94,30 @@ Install Python 3 from [python.org/downloads](https://www.python.org/downloads/)
 **"Permission denied" when running serve.sh:**
 
 Make the script executable: `chmod +x serve.sh`
+
+## Makefile Reference
+
+Run `make` with no arguments to see all available commands:
+
+```bash
+make
+```
+
+| Command | Description |
+|---|---|
+| `make serve` | Start the local server at http://localhost:8000 |
+| `make open` | Start the server and open a browser tab automatically |
+| `make validate` | Check that `site-config.json` is valid JSON |
+| `make check` | Run all available validations |
+
+You can override the default port for any server command:
+
+```bash
+make serve PORT=3000
+make open PORT=3000
+```
+
+**Note for Windows users:** `make` is not installed by default on Windows. Use the helper script or manual Python method below instead.
 
 ## What Goes Here
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# StratoLab Development Makefile
+#
+# Provides convenient shortcuts for local development.
+# Requires: Python 3 (for local server and validation)
+# Note: serve and open targets delegate to ./serve.sh
+#
+# Usage:
+#   make          Show this help
+#   make serve    Start local dev server
+#   make open     Start server and open browser
+#   make validate Check that site-config.json is valid JSON
+#   make check    Run all validations
+#
+# Override the default port:
+#   make serve PORT=3000
+#   make open  PORT=3000
+
+PORT ?= 8000
+
+.PHONY: help serve open validate check
+
+## help: Show available make targets (default)
+help:
+	@echo ""
+	@echo "StratoLab - Available commands:"
+	@echo ""
+	@grep -E '^## [a-zA-Z_-]+:' $(MAKEFILE_LIST) \
+		| sed 's/^## /  make /' \
+		| sed 's/:/ - /'
+	@echo ""
+	@echo "Override the default port: make serve PORT=3000"
+	@echo ""
+
+## serve: Start local dev server at http://localhost:$(PORT)
+serve:
+	./serve.sh -p $(PORT)
+
+## open: Start local dev server and open in default browser
+open:
+	./serve.sh -o -p $(PORT)
+
+## validate: Validate that site-config.json is valid JSON
+validate:
+	@echo "Checking site-config.json..."
+	@python3 -c "import json; json.load(open('site-config.json')); print('  site-config.json: OK')"
+
+## check: Run all validations
+check: validate
+	@echo ""
+	@echo "All checks passed."
+	@echo ""


### PR DESCRIPTION
## Summary

- Adds a `Makefile` at the repo root with `serve`, `open`, `validate`, and `check` targets
- Updates `CONTRIBUTING.md` to promote `make serve` as the recommended local dev method and adds a Makefile Reference section
- Updates `AGENTS.md` repository structure listing to include `Makefile` and `serve.sh`

## Test plan

- [ ] `make` — help text prints with all 4 targets listed
- [ ] `make serve` — dev server starts at http://localhost:8000
- [ ] `make serve PORT=3001` — server starts on port 3001
- [ ] `make open` — server starts and browser opens
- [ ] `make validate` — prints `site-config.json: OK`
- [ ] `make check` — runs validate and prints `All checks passed.`
- [ ] Review CONTRIBUTING.md in browser to confirm formatting renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)